### PR TITLE
fix(homepage): pin releaseName so ServiceAccount matches ClusterRoleBinding

### DIFF
--- a/apps/homepage/helmrelease.yaml
+++ b/apps/homepage/helmrelease.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
+  # Without releaseName, Flux composes <targetNamespace>-<name> = "homepage-homepage",
+  # which renames the chart's ServiceAccount and breaks the static ClusterRoleBinding.
+  releaseName: homepage
   targetNamespace: homepage
   chart:
     spec:


### PR DESCRIPTION
## Problem

After #231 merged, the homepage pod starts but gets `403 Forbidden` listing cluster resources:

```
User "system:serviceaccount:homepage:homepage-homepage" cannot list resource "nodes" ... at the cluster scope
```

The ServiceAccount is `homepage-homepage`, but the (raw) ClusterRoleBinding binds the role to `homepage` — so it doesn't apply.

## Root cause

Flux composes the Helm release name as `<targetNamespace>-<name>` when `spec.targetNamespace` is set and `spec.releaseName` is not. With both being `homepage`, the release name becomes `homepage-homepage`, and app-template names every chart-managed resource (including the ServiceAccount) after the release → `homepage-homepage`.

My pre-merge validation used `helm template homepage …`, which assumes release name `homepage`, so it rendered `homepage` and masked the mismatch. Lesson logged: render Flux HelmReleases with the composed name `<targetNamespace>-<name>` (or pin `releaseName`).

## Fix

Pin `spec.releaseName: homepage`. The chart then renders `ServiceAccount homepage`, matching the static ClusterRoleBinding subject.

Verified with `helm template homepage … -n homepage` → `ServiceAccount: homepage` and `serviceAccountName: homepage`.

## Rollout note

Changing the release name makes Flux uninstall the `homepage-homepage` release and install `homepage`. homepage is stateless (config is chart-managed, no PVC), so this is a clean replace with brief downtime.

## Follow-up (not in this PR)

mealie has the same doubled release name (`mealie-mealie`), but it's harmless there since nothing references the name. Worth normalizing with `releaseName` for consistency in a separate change — happy to do it, but it triggers a release replace, so flagging rather than bundling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)