### PR TITLE
Add health probes to blocky stack

### DIFF
--- a/apps/blocky/values.yaml
+++ b/apps/blocky/values.yaml
@@ -12,6 +12,37 @@ controllers:
               name: db-secret
         env:
           TZ: Europe/Berlin
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api/blocking/status
+                port: 4000
+              failureThreshold: 3
+              periodSeconds: 30
+              timeoutSeconds: 10
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api/blocking/status
+                port: 4000
+              failureThreshold: 3
+              periodSeconds: 10
+              timeoutSeconds: 1
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api/blocking/status
+                port: 4000
+              failureThreshold: 30
+              periodSeconds: 5
+              timeoutSeconds: 1
   ui:
     type: deployment
     containers:
@@ -25,6 +56,27 @@ controllers:
         envFrom:
           - secretRef:
               name: blocky-ui-secret
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: 3000
+              failureThreshold: 3
+              periodSeconds: 30
+              timeoutSeconds: 10
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: 3000
+              failureThreshold: 3
+              periodSeconds: 10
+              timeoutSeconds: 1
   redis:
     type: deployment
     containers:
@@ -32,6 +84,29 @@ controllers:
         image:
           repository: redis
           tag: "8"
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              exec:
+                command:
+                  - redis-cli
+                  - ping
+              failureThreshold: 3
+              periodSeconds: 30
+              timeoutSeconds: 5
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              exec:
+                command:
+                  - redis-cli
+                  - ping
+              failureThreshold: 3
+              periodSeconds: 10
+              timeoutSeconds: 3
 configMaps:
   config:
     enabled: true


### PR DESCRIPTION
## Summary

Adds liveness/readiness/startup probes to the three controllers in the
blocky HelmRelease, addressing part of `PLAN.md` item 3.

- **blocky** (port 4000): HTTP `GET /api/blocking/status` for all three probes; startup grace of 30×5s.
- **blocky-ui** (port 3000): HTTP `GET /` liveness + readiness (startup omitted, the SPA boots in <1s).
- **redis** (port 6379): `redis-cli ping` exec liveness + readiness.

Endpoints verified against `spx01/blocky:v0.30.0`, `gabrielduartem/blocky-ui:1.8.1`, and `redis:8`.

Convention copied from `apps/paperless/values.yaml` webserver controller.

## Test plan

- [ ] `kustomize build apps/blocky/` renders the ConfigMap with all three `probes:` blocks (verified locally)
- [ ] After merge, watch `kubectl -n blocky get pods -w` — all 5 pods (3 blocky + ui + redis) should pass readiness within ~30s
- [ ] `kubectl -n blocky describe pod <blocky-pod>` lists liveness/readiness/startup
- [ ] `kubectl -n blocky exec <blocky-pod> -- wget -qO- http://localhost:4000/api/blocking/status` returns JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)