### PR TITLE
Add health probes to paperless redis

### DIFF
--- a/apps/paperless/values.yaml
+++ b/apps/paperless/values.yaml
@@ -52,6 +52,29 @@ controllers:
         image:
           repository: redis
           tag: "8"
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              exec:
+                command:
+                  - redis-cli
+                  - ping
+              failureThreshold: 3
+              periodSeconds: 30
+              timeoutSeconds: 5
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              exec:
+                command:
+                  - redis-cli
+                  - ping
+              failureThreshold: 3
+              periodSeconds: 10
+              timeoutSeconds: 3
 service:
   webserver:
     controller: webserver


### PR DESCRIPTION
## Summary

Adds `redis-cli ping` exec liveness + readiness probes to the embedded
redis controller in the paperless HelmRelease. The webserver controller
already has full probes (liveness/readiness/startup); this completes
probe coverage for paperless per `PLAN.md` item 3.

No startup probe — redis boots in <1s.

## Test plan

- [ ] `kustomize build apps/paperless/` renders the redis probes (verified locally)
- [ ] After merge: `kubectl -n paperless describe pod <redis-pod>` lists liveness + readiness
- [ ] `kubectl -n paperless exec <redis-pod> -- redis-cli ping` returns PONG

🤖 Generated with [Claude Code](https://claude.com/claude-code)