### PR TITLE
Add health probes to mosquitto

### DIFF
--- a/apps/mosquitto/values.yaml
+++ b/apps/mosquitto/values.yaml
@@ -6,6 +6,25 @@ controllers:
         image:
           repository: eclipse-mosquitto
           tag: 2.0.22
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              tcpSocket:
+                port: 1883
+              failureThreshold: 3
+              periodSeconds: 30
+              timeoutSeconds: 5
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              tcpSocket:
+                port: 1883
+              failureThreshold: 3
+              periodSeconds: 10
+              timeoutSeconds: 3
 configMaps:
   config:
     enabled: true


### PR DESCRIPTION
## Summary

Adds TCP socket liveness + readiness probes on port 1883 to mosquitto.
MQTT is not HTTP, so a TCP check is the standard liveness signal for
`eclipse-mosquitto:2.0.22`. No startup probe — mosquitto boots in <1s.

Covers `PLAN.md` item 3 for mosquitto.

## Test plan

- [ ] `kustomize build apps/mosquitto/` renders the probes (verified locally)
- [ ] After merge: `kubectl -n mosquitto describe pod <pod>` lists liveness + readiness
- [ ] `kubectl -n mosquitto exec <pod> -- nc -zv localhost 1883` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)