### PR TITLE
Add health probes to mealie

### DIFF
--- a/apps/mealie/values.yaml
+++ b/apps/mealie/values.yaml
@@ -23,6 +23,37 @@ controllers:
         resources:
           limits:
             memory: 1Gi
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api/app/about
+                port: 9000
+              failureThreshold: 3
+              periodSeconds: 30
+              timeoutSeconds: 10
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api/app/about
+                port: 9000
+              failureThreshold: 3
+              periodSeconds: 10
+              timeoutSeconds: 3
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api/app/about
+                port: 9000
+              failureThreshold: 30
+              periodSeconds: 5
+              timeoutSeconds: 3
 service:
   app:
     controller: mealie


### PR DESCRIPTION
## Summary

Adds liveness/readiness/startup HTTP probes to mealie on
`/api/app/about:9000` — the public unauthenticated app metadata
endpoint exposed by `ghcr.io/mealie-recipes/mealie:v3.19.2`.

Startup probe is generous (30 × 5s = 2.5 min grace) to accommodate the
Python app's warm-up plus initial DB migrations.

Covers `PLAN.md` item 3 for mealie.

## Test plan

- [ ] `kustomize build apps/mealie/` renders three probe blocks (verified locally)
- [ ] After merge: pod reaches Ready within ~30s under normal startup
- [ ] `kubectl -n mealie exec <pod> -- wget -qO- http://localhost:9000/api/app/about` returns JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)