### PR TITLE
Add health probes to jellyfin

### DIFF
--- a/apps/jellyfin/values.yaml
+++ b/apps/jellyfin/values.yaml
@@ -12,6 +12,37 @@ controllers:
             gpu.intel.com/i915: 1
           limits:
             gpu.intel.com/i915: 1
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /health
+                port: 8096
+              failureThreshold: 3
+              periodSeconds: 30
+              timeoutSeconds: 10
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /health
+                port: 8096
+              failureThreshold: 3
+              periodSeconds: 10
+              timeoutSeconds: 3
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /health
+                port: 8096
+              failureThreshold: 60
+              periodSeconds: 5
+              timeoutSeconds: 3
 service:
   webserver:
     controller: webserver


### PR DESCRIPTION
## Summary

Adds liveness/readiness/startup HTTP probes on `/health:8096` to
jellyfin. The endpoint returns the literal string `Healthy` with HTTP 200
when the server is ready.

Startup probe is **5 minutes** (60 × 5s) — jellyfin's first boot includes
library/metadata scans against the NFS-mounted media volumes (audiobooks,
photos, music, videos), which can be slow.

Covers `PLAN.md` item 3 for jellyfin.

## Test plan

- [ ] `kustomize build apps/jellyfin/` renders three probe blocks (verified locally)
- [ ] After merge: pod stays unready during library scan, then passes (no liveness-induced restart loop)
- [ ] `kubectl -n jellyfin exec <pod> -- wget -qO- http://localhost:8096/health` returns `Healthy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)