### PR TITLE
Add health probes to homepage

### DIFF
--- a/apps/homepage/values.yaml
+++ b/apps/homepage/values.yaml
@@ -20,6 +20,37 @@ controllers:
                 fieldPath: status.podIP
           - name: HOMEPAGE_ALLOWED_HOSTS
             value: "$(MY_POD_IP):3000,home.homelab"
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: 3000
+              failureThreshold: 3
+              periodSeconds: 30
+              timeoutSeconds: 10
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: 3000
+              failureThreshold: 3
+              periodSeconds: 10
+              timeoutSeconds: 3
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: 3000
+              failureThreshold: 30
+              periodSeconds: 5
+              timeoutSeconds: 3
 serviceAccount:
   homepage:
     enabled: true


### PR DESCRIPTION
## Summary

Adds liveness/readiness/startup HTTP probes on `/:3000` to homepage
(`ghcr.io/gethomepage/homepage:v1.13.1`). Root path serves the dashboard
HTML and returns 200 when the app is ready.

Startup probe (30 × 5s) covers the initial ConfigMap-mounted YAML config
load.

Covers `PLAN.md` item 3 for homepage.

## Test plan

- [ ] `kustomize build apps/homepage/` renders three probe blocks (verified locally)
- [ ] After merge: `kubectl -n homepage describe pod <pod>` lists all three probes
- [ ] `curl -I http://home.homelab/` returns 200 — page reachable after rollout
- [ ] No restart loop in `kubectl -n homepage get pod` over ~2 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)