### PR TITLE
Label app values ConfigMaps for helm-controller watch

### DIFF
--- a/apps/blocky/kustomization.yaml
+++ b/apps/blocky/kustomization.yaml
@@ -7,6 +7,8 @@ configMapGenerator:
       - values.yaml
 generatorOptions:
   disableNameSuffixHash: true
+  labels:
+    reconcile.fluxcd.io/watch: Enabled
 resources:
   - namespace.yaml
   - db-secret.sops.yaml

--- a/apps/homeassistant/kustomization.yaml
+++ b/apps/homeassistant/kustomization.yaml
@@ -7,6 +7,8 @@ configMapGenerator:
       - values.yaml
 generatorOptions:
   disableNameSuffixHash: true
+  labels:
+    reconcile.fluxcd.io/watch: Enabled
 resources:
   - namespace.yaml
   - ha-configuration.sops.yaml

--- a/apps/homepage/kustomization.yaml
+++ b/apps/homepage/kustomization.yaml
@@ -11,3 +11,5 @@ configMapGenerator:
       - values.yaml
 generatorOptions:
   disableNameSuffixHash: true
+  labels:
+    reconcile.fluxcd.io/watch: Enabled

--- a/apps/jellyfin/kustomization.yaml
+++ b/apps/jellyfin/kustomization.yaml
@@ -7,6 +7,8 @@ configMapGenerator:
       - values.yaml
 generatorOptions:
   disableNameSuffixHash: true
+  labels:
+    reconcile.fluxcd.io/watch: Enabled
 resources:
   - namespace.yaml
   - jellyfin-folder.yaml

--- a/apps/mealie/kustomization.yaml
+++ b/apps/mealie/kustomization.yaml
@@ -12,3 +12,5 @@ configMapGenerator:
       - values.yaml
 generatorOptions:
   disableNameSuffixHash: true
+  labels:
+    reconcile.fluxcd.io/watch: Enabled

--- a/apps/mosquitto/kustomization.yaml
+++ b/apps/mosquitto/kustomization.yaml
@@ -7,6 +7,8 @@ configMapGenerator:
       - values.yaml
 generatorOptions:
   disableNameSuffixHash: true
+  labels:
+    reconcile.fluxcd.io/watch: Enabled
 resources:
   - namespace.yaml
   - helmrelease.yaml

--- a/apps/paperless/kustomization.yaml
+++ b/apps/paperless/kustomization.yaml
@@ -11,6 +11,8 @@ configMapGenerator:
       - values.yaml
 generatorOptions:
   disableNameSuffixHash: true
+  labels:
+    reconcile.fluxcd.io/watch: Enabled
 resources:
   - namespace.yaml
   - db-secret.sops.yaml


### PR DESCRIPTION
## Summary

Fixes the issue where Renovate's blocky v0.31.0 PR (#253) updated the
`blocky-values` ConfigMap but the running pods stayed on the old image
until manually restarted.

**Root cause:** Flux's `helm-controller` doesn't auto-watch ConfigMaps
referenced via `valuesFrom` unless they carry the label
`reconcile.fluxcd.io/watch: Enabled` (or unless the controller is run
with `--watch-configs-label-selector`). See
[Flux docs — Reacting immediately to configuration dependencies](https://fluxcd.io/flux/components/helm/helmreleases/#reacting-immediately-to-configuration-dependencies).

This PR adds the label via the existing `generatorOptions` block in each
app's kustomization that uses `configMapGenerator + valuesFrom`. All 7
affected apps:

- blocky, homeassistant, homepage, jellyfin, mealie, mosquitto, paperless

Excluded: `scraper` (Job, no HR), `zigbee2mqtt` (dedicated chart with
inline `spec.values`, no ConfigMap indirection).

### Side note

The `paperless` kustomization also generates a `settings` ConfigMap (env
vars consumed via `envFrom` on the Deployment, not via HR `valuesFrom`).
It gets the same label as a no-op — helm-controller only triggers an HR
upgrade when a labeled CM is *referenced* in valuesFrom, so labeling it
is harmless.

## Test plan

- [x] `prek run --files apps/*/kustomization.yaml` passes
- [x] `kustomize build apps/<app>/` shows the new label on each
      `<app>-values` ConfigMap (verified for all 7)
- [ ] After merge: `kubectl -n flux-system get cm blocky-values -o yaml | grep watch` shows the label
- [ ] End-to-end: bump an inconsequential field in any app's `values.yaml`,
      merge, watch `flux events --for HelmRelease/<app> --watch` — should
      reconcile within seconds, not 5 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)