### PR TITLE
Add authentik base setup

### DIFF
--- a/apps/authentik-helmrepo.yaml
+++ b/apps/authentik-helmrepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: authentik
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.goauthentik.io

--- a/apps/authentik/authentik-secret.sops.yaml
+++ b/apps/authentik/authentik-secret.sops.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: authentik-secret
+    namespace: authentik
+type: Opaque
+stringData:
+    AUTHENTIK_SECRET_KEY: ENC[AES256_GCM,data:yfuiHycjEAS26TbuOn1HxWJnZKBwyOK5O82f+StVaFHgWp3Xc7sPw8DXOPwyt2ZgZgIDJULkOWGmFI1k+eky9i48I3ZTDzxAOpzfGQ4zxr0=,iv:+9LWrwHJk3YmTc69xtnKg7bbJWw/kOcA1nCvcCtM1/A=,tag:F5E8J5BVWfZ98IN0yyoTXQ==,type:str]
+    AUTHENTIK_POSTGRESQL__PASSWORD: ENC[AES256_GCM,data:C9QOqi4I+LwDGYAGjFiOmLrKhuhBmP187PHCrlRENcsHIybC3iJP7XMgTfJtpyre,iv:KVz/Gwk1pf0E4mKwB73fvam4VXeQd+XgqT4aRqt8jBI=,tag:T4ym7pLfgOLmOxLqIDDNow==,type:str]
+    AUTHENTIK_BOOTSTRAP_PASSWORD: ENC[AES256_GCM,data:dAuT/x93Tpln8JEQ9ppzDF2UPmxtVrDzuJrFxx5lb2Q=,iv:+X9YTG9xCBTIrB1tj+BkMqfQkHaWJ3PiNfVbLThPUHQ=,tag:e/NRCnfDNSlcUKxVS2mgtA==,type:str]
+    AUTHENTIK_BOOTSTRAP_TOKEN: ENC[AES256_GCM,data:QozpxsL8xIgmj9qcVcEuhRMERSh8pW7DXv/Hub8iqODkt4az7OEnjfjYuxhKPrEfq14crdxKj3FymyCPSJfhMg==,iv:licSFr1QSwBpQ5elOb7C6Gq3wil4LWhtaTRbI3fOlr0=,tag:s+JrX6Di4vEbYiq0zDNt5g==,type:str]
+    AUTHENTIK_BOOTSTRAP_EMAIL: ENC[AES256_GCM,data:p9FlqtAhMlCC9jXkWfDnJyCN6IfmVJkQ2TVi,iv:X11ALoopdpJriUCwr++43/yX93enDLBo9kTg+pch0gY=,tag:elh0SM5MWbwCdAi/kMFs4g==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoVXEvM0dwZnU0VmJsZXRo
+            aE1IZGZxL3RrTFZRSWY2cFZzRkFneXJsYUU0CnhENzFqWnlvcUswc25nekZIdkZz
+            cEZjMGZvTEhUZG1Ya0ZjNlNYQXRpL00KLS0tIGYxQmJaK0xseW5MdTlXajlYOEtL
+            QUxsQ2JMdnlJWk1kUmxhaGcyT1dPUTgKhjiiOoQhZaI+zZZDU3DVjRe+MSIYok7U
+            BWJDZMhu20g9CZe0rHW5zvsHNFx1g04pErlQNNz9F5sxNXFh3SfD8g==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1d06qu8eegt8wf8pewe8gw50jrrxt8wwzjhqhxgnl7f4myq9dzdxsdrps49
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-17T15:16:24Z"
+    mac: ENC[AES256_GCM,data:EoPJAViZ9L+DYq+EWMFQxlr9w+VfYVRfyG6egYuQpYeg+okJoine0eTyohI5qeF4Qeg8XQ0Yp9eIwFzut4n14pptxRQDFLeGndF2hK0ZhjlnPCtrz+5Av+CDR5IT0ua13EXQjBkmwj+Bm2ccUlQiyGl7oItbHf24gISnbsRZMAY=,iv:VxYSjcWJFL8g/AsOkQcDNHLK4V1P97whuI1XzpENRfU=,tag:hM1CORRIBul2bpPXmcN5sA==,type:str]
+    version: 3.13.1

--- a/apps/authentik/authentik-secret.sops.yaml
+++ b/apps/authentik/authentik-secret.sops.yaml
@@ -5,10 +5,10 @@ metadata:
     namespace: authentik
 type: Opaque
 stringData:
-    AUTHENTIK_SECRET_KEY: ENC[AES256_GCM,data:yfuiHycjEAS26TbuOn1HxWJnZKBwyOK5O82f+StVaFHgWp3Xc7sPw8DXOPwyt2ZgZgIDJULkOWGmFI1k+eky9i48I3ZTDzxAOpzfGQ4zxr0=,iv:+9LWrwHJk3YmTc69xtnKg7bbJWw/kOcA1nCvcCtM1/A=,tag:F5E8J5BVWfZ98IN0yyoTXQ==,type:str]
-    AUTHENTIK_POSTGRESQL__PASSWORD: ENC[AES256_GCM,data:C9QOqi4I+LwDGYAGjFiOmLrKhuhBmP187PHCrlRENcsHIybC3iJP7XMgTfJtpyre,iv:KVz/Gwk1pf0E4mKwB73fvam4VXeQd+XgqT4aRqt8jBI=,tag:T4ym7pLfgOLmOxLqIDDNow==,type:str]
-    AUTHENTIK_BOOTSTRAP_PASSWORD: ENC[AES256_GCM,data:dAuT/x93Tpln8JEQ9ppzDF2UPmxtVrDzuJrFxx5lb2Q=,iv:+X9YTG9xCBTIrB1tj+BkMqfQkHaWJ3PiNfVbLThPUHQ=,tag:e/NRCnfDNSlcUKxVS2mgtA==,type:str]
-    AUTHENTIK_BOOTSTRAP_TOKEN: ENC[AES256_GCM,data:QozpxsL8xIgmj9qcVcEuhRMERSh8pW7DXv/Hub8iqODkt4az7OEnjfjYuxhKPrEfq14crdxKj3FymyCPSJfhMg==,iv:licSFr1QSwBpQ5elOb7C6Gq3wil4LWhtaTRbI3fOlr0=,tag:s+JrX6Di4vEbYiq0zDNt5g==,type:str]
+    AUTHENTIK_SECRET_KEY: ENC[AES256_GCM,data:piWNfnRFp5GOIRbOHE6xAHpj2cCjvuXwY1UVLzHzRB1usZE811QN1JOvRKYiV2amAJkvcoFDd408GeTtcvo9CC8EikI4j8z+TDtAmlVBfmw=,iv:4oVoHjjfmR12jStapjwKULNeYNU6skxzp8CjBuRJFQg=,tag:4FpkPd++lhgWUXrahbcJHg==,type:str]
+    AUTHENTIK_POSTGRESQL__PASSWORD: ENC[AES256_GCM,data:9Pt4ttS8BOkB9/+8WnfSutiqqzeAmTQrt7f5rsx2Kg58REU81k/Ghg==,iv:W/r0O/UgwOz0I4XkRqnHDrPh1uhEnU2KzPt4LJhVS7k=,tag:x3qup6huo2Ja+Kp+tF7HhQ==,type:str]
+    AUTHENTIK_BOOTSTRAP_PASSWORD: ENC[AES256_GCM,data:gkL0ud+Bl3dVpmrNRrAdMc0G6wK8juMw06kySk0e,iv:mC1E5hrwwYcI7xPWpag2zpEOeWcYmgemFXaxKetOj7s=,tag:0WjYAfYBFHVF3WUqxTfvQQ==,type:str]
+    AUTHENTIK_BOOTSTRAP_TOKEN: ENC[AES256_GCM,data:v5UMkALVfPpCuK7kKkC30rvU0yv8yO7wVJyFeRpUYLyGVJD/b7uqLDmWVTa9NGwRlb4E3lQo93RpWVpn,iv:ug7P96GZUkTBN8dfR03fIw9VLFRzQUJ/EsjDk7z6YCo=,tag:8dNfc2AqNX6h8aXwnyv5cg==,type:str]
     AUTHENTIK_BOOTSTRAP_EMAIL: ENC[AES256_GCM,data:p9FlqtAhMlCC9jXkWfDnJyCN6IfmVJkQ2TVi,iv:X11ALoopdpJriUCwr++43/yX93enDLBo9kTg+pch0gY=,tag:elh0SM5MWbwCdAi/kMFs4g==,type:str]
 sops:
     age:
@@ -22,6 +22,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1d06qu8eegt8wf8pewe8gw50jrrxt8wwzjhqhxgnl7f4myq9dzdxsdrps49
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-17T15:16:24Z"
-    mac: ENC[AES256_GCM,data:EoPJAViZ9L+DYq+EWMFQxlr9w+VfYVRfyG6egYuQpYeg+okJoine0eTyohI5qeF4Qeg8XQ0Yp9eIwFzut4n14pptxRQDFLeGndF2hK0ZhjlnPCtrz+5Av+CDR5IT0ua13EXQjBkmwj+Bm2ccUlQiyGl7oItbHf24gISnbsRZMAY=,iv:VxYSjcWJFL8g/AsOkQcDNHLK4V1P97whuI1XzpENRfU=,tag:hM1CORRIBul2bpPXmcN5sA==,type:str]
+    lastmodified: "2026-06-17T19:52:04Z"
+    mac: ENC[AES256_GCM,data:nY+barrgBTQTz+fZWF+r58awHouzh+GauLQiUSeYct6Y8SLZPuK98+wxN16PGYNjcrXoh90kCyXdzIpRbmBWIJ7PyRxJo2m7ZKNjY8Ist9VxgW4XMZqubXKQ0QtzFDoiJ2S+sfOmXGGiE13m9638CSqMWJ5swEUjw3euOvvbbLg=,iv:pi5SUBJsPKTqsH5U3XL1rU+X2cCDNq5rJI+1LxV6awQ=,tag:qq+GGbiw0CLt/ELQ+QTM4w==,type:str]
     version: 3.13.1

--- a/apps/authentik/helmrelease.yaml
+++ b/apps/authentik/helmrelease.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: authentik
+  namespace: flux-system
+spec:
+  interval: 5m
+  releaseName: authentik
+  targetNamespace: authentik
+  chart:
+    spec:
+      chart: authentik
+      version: "2026.5.3"
+      sourceRef:
+        kind: HelmRepository
+        name: authentik
+        namespace: flux-system
+      interval: 10m
+  valuesFrom:
+    - kind: ConfigMap
+      name: authentik-values
+      valuesKey: values.yaml

--- a/apps/authentik/kustomization.yaml
+++ b/apps/authentik/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - authentik-secret.sops.yaml
+  - helmrelease.yaml
+configMapGenerator:
+  - name: authentik-values
+    namespace: flux-system
+    files:
+      - values.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+  labels:
+    reconcile.fluxcd.io/watch: Enabled

--- a/apps/authentik/namespace.yaml
+++ b/apps/authentik/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: authentik
+  labels:
+    app.kubernetes.io/component: monitoring

--- a/apps/authentik/values.yaml
+++ b/apps/authentik/values.yaml
@@ -1,0 +1,61 @@
+authentik:
+  error_reporting:
+    enabled: false
+  postgresql:
+    # Connect directly to the CNPG primary, NOT the pgbouncer pooler: authentik
+    # (post-Redis) relies on PostgreSQL LISTEN/NOTIFY and advisory locks, which
+    # are unreliable through a pooled connection.
+    host: cnpg-cluster-rw.cnpg-cluster.svc
+    name: authentikdb
+    user: authentik
+    port: 5432
+    # password injected via AUTHENTIK_POSTGRESQL__PASSWORD (global.env below)
+
+global:
+  env:
+    - name: AUTHENTIK_SECRET_KEY
+      valueFrom:
+        secretKeyRef:
+          name: authentik-secret
+          key: AUTHENTIK_SECRET_KEY
+    - name: AUTHENTIK_POSTGRESQL__PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: authentik-secret
+          key: AUTHENTIK_POSTGRESQL__PASSWORD
+    - name: AUTHENTIK_BOOTSTRAP_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: authentik-secret
+          key: AUTHENTIK_BOOTSTRAP_PASSWORD
+    - name: AUTHENTIK_BOOTSTRAP_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: authentik-secret
+          key: AUTHENTIK_BOOTSTRAP_TOKEN
+    - name: AUTHENTIK_BOOTSTRAP_EMAIL
+      valueFrom:
+        secretKeyRef:
+          name: authentik-secret
+          key: AUTHENTIK_BOOTSTRAP_EMAIL
+
+# Use the external CloudNativePG cluster instead of the bundled Bitnami subchart.
+postgresql:
+  enabled: false
+
+server:
+  ingress:
+    enabled: true
+    ingressClassName: traefik
+    annotations:
+      gethomepage.dev/description: Identity Provider / SSO
+      gethomepage.dev/enabled: "true"
+      gethomepage.dev/group: Apps
+      gethomepage.dev/icon: authentik.png
+      gethomepage.dev/name: Authentik
+    hosts:
+      - authentik.${EXTERNAL_DOMAIN}
+      - authentik.${LOCAL_DOMAIN}
+
+worker:
+  enabled: true

--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - bjw-s-helmrepo.yaml
+  - authentik-helmrepo.yaml
+  - authentik
   - blocky
   - scraper
   - immich

--- a/infrastructure/cnpg-extras/authentik-db-secret.sops.yaml
+++ b/infrastructure/cnpg-extras/authentik-db-secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: authentik-db-secret
+    namespace: cnpg-cluster
+type: kubernetes.io/basic-auth
+stringData:
+    username: ENC[AES256_GCM,data:4nqATLVfF0lx,iv:zDUsTbzIH7ahRjpVrpTzp/6XCjFasXvKA5uv5dnICs0=,tag:1b22QNM79ZQtVOIGU5WH7w==,type:str]
+    password: ENC[AES256_GCM,data:zC81y5UjVKc4N/ghhkMn5auQGx+hWLLvuGmCnHv+4IcHInVZQCsxEkV14xSgYMMv,iv:eWzNKZehr3RDsqJf9Wjq1xm0YbpHwvnTsciMgLZEL6E=,tag:E9XSCd8qoKVOQeo+NRnmMw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6SmxJeXE3MG1KdHVld3FF
+            QmN4N1pBQ0c0YytFRWdUR1lrREJ2TVVwekJBCkJwWUR2T09taUt0cS9BbFE4SStX
+            Z1h3Z2huZzNFNDc0cWlENjl0bzNMdVEKLS0tIDZ6NHlIU04vaFFRVk1RNmZtbDkx
+            TThZcUFZU3VQbE95WEo1Y215L3FWQ28KVfDJNtTnYaBxrIsYNb7krbYaiOaHzva/
+            mh0QEnmkBJxAQI6VYo0Jt1d8AAKwzsSNCkZcTNyEyPIIJ7b9iT73Mw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1d06qu8eegt8wf8pewe8gw50jrrxt8wwzjhqhxgnl7f4myq9dzdxsdrps49
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-17T15:16:24Z"
+    mac: ENC[AES256_GCM,data:7pFNqFH8XDS6CFWqm/uSrGIu76DS/ktqMQ37ukcY6lEJunpmICAxLT8PQQhAsC10F9vBhuUHeh1A7gmjmj1bz8RlDRPtWjkQx8OJcWvSsARW/6Dm1npHo36rnEBdsmbj8guuo18e6mBMJuHZddDn/eOYDUo6mOhvX/bO1GhJqWU=,iv:Vw8h1fSza3+CmVqDFfIkRushA5brkxXRXxxrP3PqS44=,tag:sdIGMzF4ziIclXcpBBBA9w==,type:str]
+    version: 3.13.1

--- a/infrastructure/cnpg-extras/authentik-db-secret.sops.yaml
+++ b/infrastructure/cnpg-extras/authentik-db-secret.sops.yaml
@@ -6,7 +6,7 @@ metadata:
 type: kubernetes.io/basic-auth
 stringData:
     username: ENC[AES256_GCM,data:4nqATLVfF0lx,iv:zDUsTbzIH7ahRjpVrpTzp/6XCjFasXvKA5uv5dnICs0=,tag:1b22QNM79ZQtVOIGU5WH7w==,type:str]
-    password: ENC[AES256_GCM,data:zC81y5UjVKc4N/ghhkMn5auQGx+hWLLvuGmCnHv+4IcHInVZQCsxEkV14xSgYMMv,iv:eWzNKZehr3RDsqJf9Wjq1xm0YbpHwvnTsciMgLZEL6E=,tag:E9XSCd8qoKVOQeo+NRnmMw==,type:str]
+    password: ENC[AES256_GCM,data:C2z+JnVPc1YmrXEG2OVxHQZDCpznBRDqoXhVrOnthBfpSMN6p0IWiQ==,iv:dpGONupc/NINXLfguiITQW6gv0kqVS77wgO/iFifnaI=,tag:7uxETTRDt6u/zt3EWsV3cg==,type:str]
 sops:
     age:
         - enc: |
@@ -19,6 +19,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1d06qu8eegt8wf8pewe8gw50jrrxt8wwzjhqhxgnl7f4myq9dzdxsdrps49
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-17T15:16:24Z"
-    mac: ENC[AES256_GCM,data:7pFNqFH8XDS6CFWqm/uSrGIu76DS/ktqMQ37ukcY6lEJunpmICAxLT8PQQhAsC10F9vBhuUHeh1A7gmjmj1bz8RlDRPtWjkQx8OJcWvSsARW/6Dm1npHo36rnEBdsmbj8guuo18e6mBMJuHZddDn/eOYDUo6mOhvX/bO1GhJqWU=,iv:Vw8h1fSza3+CmVqDFfIkRushA5brkxXRXxxrP3PqS44=,tag:sdIGMzF4ziIclXcpBBBA9w==,type:str]
+    lastmodified: "2026-06-17T19:51:25Z"
+    mac: ENC[AES256_GCM,data:WQkSlyZf26SiCdMDLZ4brvlpjk3Mgz7r6PogvcOBCcQMiWAj1r07W6ChD9s29C+4ZqQglht1uSEJrSSCaW8p+/bxagwpEJDGofBw13AWrXDtxrtUHQuCEo2IbmkIc9dv/8FSDLD+EHOcMNvKkuDpLTxP8rkNniWG2a0pRHBm4S4=,iv:/ohHTZbrOyUuu75boVYeZ55wrj2Tejw7Z1wDIr1ploM=,tag:FY19G3jVJuvZzU6iGLpsew==,type:str]
     version: 3.13.1

--- a/infrastructure/cnpg-extras/cluster.yaml
+++ b/infrastructure/cnpg-extras/cluster.yaml
@@ -73,3 +73,12 @@ spec:
         inRoles:
           - pg_monitor
           - pg_signal_backend
+      - name: authentik
+        ensure: present
+        login: true
+        superuser: false
+        passwordSecret:
+          name: authentik-db-secret
+        inRoles:
+          - pg_monitor
+          - pg_signal_backend

--- a/infrastructure/cnpg-extras/databases.yaml
+++ b/infrastructure/cnpg-extras/databases.yaml
@@ -62,3 +62,14 @@ spec:
       ensure: present
     - name: earthdistance
       ensure: present
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: authentikdb
+  namespace: cnpg-cluster
+spec:
+  name: authentikdb
+  owner: authentik
+  cluster:
+    name: cnpg-cluster

--- a/infrastructure/cnpg-extras/kustomization.yaml
+++ b/infrastructure/cnpg-extras/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - cnpg-superuser-password.sops.yaml
   - mealie-db-secret.sops.yaml
   - immich-db-secret.sops.yaml
+  - authentik-db-secret.sops.yaml
   - cluster.yaml
   - scheduled-backup.yaml
   - pgbouncer.yaml


### PR DESCRIPTION
## Context
First of three PRs introducing **authentik** as the homelab's overarching SSO/identity provider. This PR stands up authentik itself; later PRs wire up the individual apps.

Backed by the **2026.05** authentik docs (chart `2026.5.3`). Notably, [authentik removed Redis in 2025.10](https://goauthentik.io/blog/2025-11-13-we-removed-redis/), so 2026.5 needs **only PostgreSQL** — it slots straight onto the existing CloudNativePG cluster.

## What's included
- **`apps/authentik/`** — official Helm chart via new `authentik` HelmRepository, HelmRelease, values, namespace, and a SOPS secret holding `secret_key`, the DB password, and bootstrap admin credentials (`AUTHENTIK_BOOTSTRAP_*`).
- **CNPG** — new `authentik` managed role, `authentikdb` database, and role password secret, following the existing per-app pattern.
- **DB connection** goes directly to the CNPG primary `cnpg-cluster-rw` (not the PgBouncer pooler): post-Redis, authentik uses PostgreSQL `LISTEN/NOTIFY` and advisory locks, which are unreliable through a pooled connection.
- Exposed at `authentik.${EXTERNAL_DOMAIN}` / `authentik.${LOCAL_DOMAIN}`, LAN-only behind the existing Traefik middleware.

## Verification
- `kustomize build apps` and `kustomize build infrastructure/cnpg-extras` succeed; `prek`/yamllint pass.
- After merge/reconcile: CNPG shows `authentikdb` + `authentik` role; `server` and `worker` pods become Ready; **no Redis pod**; first login as `akadmin` works.

## Follow-ups
- PR2: grafana, mealie, immich, jellyfin (uncritical services)
- PR3: homeassistant, paperless (critical services)

🤖 Generated with [Claude Code](https://claude.com/claude-code)