### PR TITLE
Integrate Grafana, Mealie, Immich, Jellyfin with authentik

### DIFF
--- a/apps/authentik/authentik-oidc-credentials.sops.yaml
+++ b/apps/authentik/authentik-oidc-credentials.sops.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: authentik-oidc-credentials
+    namespace: authentik
+type: Opaque
+stringData:
+    GRAFANA_CLIENT_ID: ENC[AES256_GCM,data:H5y/kEi+QUH/ISeRscI2/G+OiPr1Gr/Mbxiyh1x+HF1Ws6DkYYB1bw==,iv:oZF/Iz+zFcEQ4sK0Ow0iKArcpvb20cPPWvtmxxSyLD0=,tag:G2N7EYmNxpkRgFtdIaFJVw==,type:str]
+    GRAFANA_CLIENT_SECRET: ENC[AES256_GCM,data:Fhv6/lUgpa8vzsCPL2mLVeamt2al2zW46qYiZy90xsuieeqXd8n8ksXHT5XcC/EGpFUx7S/0x39Ck01EenF+SYiwa2WBNcx8xqPEIbvMhwPkQniFaSFu/XI4515LNhzEVcgc9KcnpufrMmXL3gcmeCcezdGYlHnc5Sou3KI2vAQ=,iv:Cq8zehwwjMAboabFv7QFgoBQQT8tau2/FdGrx3uNUsI=,tag:ozIYgKGLkJBjCsv/Gq2efQ==,type:str]
+    MEALIE_CLIENT_ID: ENC[AES256_GCM,data:44As9xR3/bNj63uIZR7L/+NRfp+S3PpfC5IKrXQ2VsCusIkuBiZJ5Q==,iv:jlggJavClHsXIp3RNX2c2opr1WSzO+xEkKz3bV327d0=,tag:uFMYmOjeV8iGnKXbVdhKog==,type:str]
+    MEALIE_CLIENT_SECRET: ENC[AES256_GCM,data:ETsAySZq1VpY5XnY7Ewi21SGvIJtsRu5Qc1LDMz2IIFmxo4udOgwTBM1Hb69BkfKxXPfJ+k7uEkb+pBa9qckwo/RszBZg69aZ8sca9EjM0hkWKnejoyHQ4KoDdBMnNF3MmypFSDgYy1p4UVy2wjEp1iGoouvqqMXzzkq+N8Bvrw=,iv:V/qenCVwaZzsFnW6DLjKsjhkXZZU4INJqcsvTFJTZSk=,tag:KyMaVTq5EA2GP/A5YMzKfQ==,type:str]
+    IMMICH_CLIENT_ID: ENC[AES256_GCM,data:3QfiGVohOX9UBXdMzbs3X+s9AdAaOBj1oVvmhmcuF/tBTCSfIQSo/g==,iv:VBFhuj7f6u7RB+/NREwVg4Ek2dNF+HKXzPU0wEGsJzI=,tag:wocd+05Y4cyMi4Wbzc8s/w==,type:str]
+    IMMICH_CLIENT_SECRET: ENC[AES256_GCM,data:m4odqgHSIFdoj9EcDNV6VZFiCScZAex9H+mVxaS2qKeVD9FVquonYKjby1W5D9XU/AyrgjME/Oq+tZPL/RN6c3fBI1oEIOpi4nSbHFVWE4k8BN5MSX0gaLR2Q5b0mARaXnHd/wiY9tsudoEqwWIx2yiEOYbID906WThBz03j5Gs=,iv:6A2/7bwvq3WrtoF7GCFa1u8/jAD4crmOu9p9mOQtwDk=,tag:GID/3vHiSZnjcvqMbWCimA==,type:str]
+    JELLYFIN_CLIENT_ID: ENC[AES256_GCM,data:a9SnOROjNJUhd+UXT7qc0bJ+hT0XS//39/X6vcyOtIJzPhqtkSyPzA==,iv:G9CdTnsLY9Y2lCqH/GCExxzE7LetW3wFhEMuF1Zx624=,tag:Hr4CwHnJys5Pihz22nlO3g==,type:str]
+    JELLYFIN_CLIENT_SECRET: ENC[AES256_GCM,data:hOKRJfCBRmyz4//RM7rY2CaBkn85n4XEV0PSVURVFp/NbZzUmksyXJaCirs4FtgY/105lxESN31ZI7h1HPj3KnricET3Afa9McGe08gIXnFkV8ABZfwGB2ApZrs3NxNKZPtia9g2qOHfSp/VFED6R9/ADZPPh+2gzzPkXevqquI=,iv:d+5lmiiw39HC6qQQ0y+Fpb3wVcphnxr2905lb4kqSig=,tag:w6+07ILmVfdGOeazG7Hozw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2ZDVuYXNENkpTRVFmdnNU
+            WE00T0UvbW5rWGdoS2hPaU9pV0JDdXFnY3djCk5YRXBTa2hGWS9WdGg3TXE4OGpp
+            Z2ZvS1dGcUVPYXVVU203WDc3bi9UNnMKLS0tIGpXaW83clVJL1FoNmtnUGNjV3Bl
+            OGhpc2hkaHlhbWJSL1NxNFFvZU9pd1UKjO1qNp+9VeEXlziHZRMIaqK+yjilUHVe
+            gz6QQ1KJBoQgVL2cu5Ov5pmT+wZ32Oargt4KEMb1RSrMwBqji+KnkA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1d06qu8eegt8wf8pewe8gw50jrrxt8wwzjhqhxgnl7f4myq9dzdxsdrps49
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-17T15:27:20Z"
+    mac: ENC[AES256_GCM,data:+40g68u9Er11dO8w7dCKKRXH7qANV6jbFDopANsxUMaDd8ZFjdIETSTGw5B3igSfxMdAPmIjdlbAspKE/WkAYA4nUbYK3fjYJ+XcCUYU3QlXoWRAnfeac10YZ2f5U3JdYiwsKpB86dDeM3P+ogFiKEpKF5DOvrbTzqDsghIPmbo=,iv:srpFCeAGs2sSv78Hytfht3WvIhG+VXJSg39nWPlPcMQ=,tag:pg4HaKhs1U+ramjerdqW7A==,type:str]
+    version: 3.13.1

--- a/apps/authentik/blueprints/homelab-uncritical.yaml
+++ b/apps/authentik/blueprints/homelab-uncritical.yaml
@@ -1,0 +1,175 @@
+# authentik blueprint: groups, OAuth2 providers and applications for the
+# "uncritical" services (Grafana, Mealie, Immich, Jellyfin).
+#
+# Client IDs/secrets are injected into the authentik server+worker as env vars
+# (from the SOPS secret authentik-oidc-credentials) and read here via !Env, so
+# this blueprint contains no secrets. ${EXTERNAL_DOMAIN}/${LOCAL_DOMAIN} are
+# substituted by Flux postBuild.
+version: 1
+metadata:
+  name: homelab-sso-uncritical
+entries:
+  # --- Groups ------------------------------------------------------------
+  - model: authentik_core.group
+    identifiers:
+      name: grafana-admins
+    attrs:
+      name: grafana-admins
+  - model: authentik_core.group
+    identifiers:
+      name: grafana-editors
+    attrs:
+      name: grafana-editors
+  - model: authentik_core.group
+    identifiers:
+      name: mealie-admins
+    attrs:
+      name: mealie-admins
+  - model: authentik_core.group
+    identifiers:
+      name: mealie-users
+    attrs:
+      name: mealie-users
+  - model: authentik_core.group
+    identifiers:
+      name: homelab-users
+    attrs:
+      name: homelab-users
+
+  # --- Grafana -----------------------------------------------------------
+  - model: authentik_providers_oauth2.oauth2provider
+    id: provider-grafana
+    identifiers:
+      name: grafana
+    attrs:
+      name: grafana
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      client_type: confidential
+      client_id: !Env GRAFANA_CLIENT_ID
+      client_secret: !Env GRAFANA_CLIENT_SECRET
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      redirect_uris:
+        - url: "https://grafana.${EXTERNAL_DOMAIN}/login/generic_oauth"
+          matching_mode: strict
+        - url: "https://grafana.homelab/login/generic_oauth"
+          matching_mode: strict
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+  - model: authentik_core.application
+    identifiers:
+      slug: grafana
+    attrs:
+      name: Grafana
+      slug: grafana
+      provider: !KeyOf provider-grafana
+      meta_launch_url: "https://grafana.${EXTERNAL_DOMAIN}"
+      policy_engine_mode: any
+
+  # --- Mealie ------------------------------------------------------------
+  - model: authentik_providers_oauth2.oauth2provider
+    id: provider-mealie
+    identifiers:
+      name: mealie
+    attrs:
+      name: mealie
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      client_type: confidential
+      client_id: !Env MEALIE_CLIENT_ID
+      client_secret: !Env MEALIE_CLIENT_SECRET
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      redirect_uris:
+        - url: "https://mealie.${EXTERNAL_DOMAIN}/login"
+          matching_mode: strict
+        - url: "https://mealie.${EXTERNAL_DOMAIN}/login?direct=1"
+          matching_mode: strict
+        - url: "https://mealie.homelab/login"
+          matching_mode: strict
+        - url: "https://mealie.homelab/login?direct=1"
+          matching_mode: strict
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+  - model: authentik_core.application
+    identifiers:
+      slug: mealie
+    attrs:
+      name: Mealie
+      slug: mealie
+      provider: !KeyOf provider-mealie
+      meta_launch_url: "https://mealie.${EXTERNAL_DOMAIN}"
+      policy_engine_mode: any
+
+  # --- Immich ------------------------------------------------------------
+  - model: authentik_providers_oauth2.oauth2provider
+    id: provider-immich
+    identifiers:
+      name: immich
+    attrs:
+      name: immich
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      client_type: confidential
+      client_id: !Env IMMICH_CLIENT_ID
+      client_secret: !Env IMMICH_CLIENT_SECRET
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      redirect_uris:
+        - url: "app.immich:///oauth-callback"
+          matching_mode: strict
+        - url: "https://immich.${EXTERNAL_DOMAIN}/auth/login"
+          matching_mode: strict
+        - url: "https://immich.${EXTERNAL_DOMAIN}/user-settings"
+          matching_mode: strict
+        - url: "https://immich.${LOCAL_DOMAIN}/auth/login"
+          matching_mode: strict
+        - url: "https://immich.${LOCAL_DOMAIN}/user-settings"
+          matching_mode: strict
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+  - model: authentik_core.application
+    identifiers:
+      slug: immich
+    attrs:
+      name: Immich
+      slug: immich
+      provider: !KeyOf provider-immich
+      meta_launch_url: "https://immich.${EXTERNAL_DOMAIN}/auth/login?autoLaunch=1"
+      policy_engine_mode: any
+
+  # --- Jellyfin ----------------------------------------------------------
+  - model: authentik_providers_oauth2.oauth2provider
+    id: provider-jellyfin
+    identifiers:
+      name: jellyfin
+    attrs:
+      name: jellyfin
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      client_type: confidential
+      client_id: !Env JELLYFIN_CLIENT_ID
+      client_secret: !Env JELLYFIN_CLIENT_SECRET
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      redirect_uris:
+        - url: "https://jellyfin.${EXTERNAL_DOMAIN}/sso/OID/redirect/authentik"
+          matching_mode: strict
+        - url: "https://jellyfin.homelab/sso/OID/redirect/authentik"
+          matching_mode: strict
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+  - model: authentik_core.application
+    identifiers:
+      slug: jellyfin
+    attrs:
+      name: Jellyfin
+      slug: jellyfin
+      provider: !KeyOf provider-jellyfin
+      meta_launch_url: "https://jellyfin.${EXTERNAL_DOMAIN}/sso/OID/start/authentik"
+      policy_engine_mode: any

--- a/apps/authentik/kustomization.yaml
+++ b/apps/authentik/kustomization.yaml
@@ -3,12 +3,17 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - authentik-secret.sops.yaml
+  - authentik-oidc-credentials.sops.yaml
   - helmrelease.yaml
 configMapGenerator:
   - name: authentik-values
     namespace: flux-system
     files:
       - values.yaml
+  - name: authentik-blueprints
+    namespace: authentik
+    files:
+      - blueprints/homelab-uncritical.yaml
 generatorOptions:
   disableNameSuffixHash: true
   labels:

--- a/apps/authentik/values.yaml
+++ b/apps/authentik/values.yaml
@@ -44,6 +44,9 @@ postgresql:
   enabled: false
 
 server:
+  envFrom:
+    - secretRef:
+        name: authentik-oidc-credentials
   ingress:
     enabled: true
     ingressClassName: traefik
@@ -59,3 +62,11 @@ server:
 
 worker:
   enabled: true
+  envFrom:
+    - secretRef:
+        name: authentik-oidc-credentials
+
+# Declarative providers/applications applied by the worker on startup.
+blueprints:
+  configMaps:
+    - authentik-blueprints

--- a/apps/mealie/kustomization.yaml
+++ b/apps/mealie/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - namespace.yaml
   - app-data.yaml
   - db-secret.sops.yaml
+  - oidc-secret.sops.yaml
   - helmrelease.yaml
 configMapGenerator:
   - name: mealie-values

--- a/apps/mealie/oidc-secret.sops.yaml
+++ b/apps/mealie/oidc-secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: oidc-secret
+    namespace: mealie
+type: Opaque
+stringData:
+    OIDC_CLIENT_ID: ENC[AES256_GCM,data:eIsoto+s/StNpXVp7nm4JGleZXU679MV12TSyab9JfqSZE7Ftn4uYQ==,iv:lW6HGYze3he+3arOxwa03pbud+F2kHYbg90dro8afcY=,tag:iCl5zAFkC09dYb5IHOfNdw==,type:str]
+    OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:wq6/chUM1dDNuMDOZIrTJwAm/PT8rarfKBTjatrMGVv23zU4gqPeypu2AV/hTJKLCYv4ZtZp3+npTqrLXhCmZd25b11faU1eOwIh5wz9OSOX2fmrMoit+hKNNbfjnbfOFvTJb6IKMa42SNQceMecRqmG1NvyDptrFhOLi2rLjVA=,iv:EZ2Pe0CFMW1mQTe730wa8p83KFgpT5JbJoAfht2s0fk=,tag:shXzrnQl4IOtVpWwURxZWw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmZ1MwZFh6VGV0ZHR2bGlo
+            Y3pUVWkvOWVZR09oc09CN3pRNHVRTDJ4ZUNnCkJraTk4YUVJQUVkSzlKMDcrNlc0
+            ZWw3SkVIeU1sSnVsYk42Z3FxaVpESVkKLS0tIGFheTludjJrcWxBZk44azBKTU8x
+            UHBXSXl1RTVlT0RaSHlqUk42amZmK2sK01fWkdthVdQraOVyAyF7RYpgTIf5k2qe
+            Vs4qQojBLxV+YkBK5rGxkdChTbbC8xIhK7KjTG2LCELkDcutOmCREA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1d06qu8eegt8wf8pewe8gw50jrrxt8wwzjhqhxgnl7f4myq9dzdxsdrps49
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-17T15:27:20Z"
+    mac: ENC[AES256_GCM,data:nNzq4GNYp1iK/ofmgGTUxHG2zFzbn867rpS9/rNq2JLkAsQIi9EM1i1ca3i0e3HqzlBCIHJtxw47DMui9K2dYbEo1rYvvD3eXVFiwXZkGLYAJapSEP4p6LcHtF5i71eB/pevqEJGfVYLHRStHZeVpbq73ea36UhDXvqBFs5UOqo=,iv:nW1mYOy+U0tnuMYKfaujpdD5y0wAga/VLv7kHjTcRYY=,tag:8gnRwlDMn32ga44njdDvVQ==,type:str]
+    version: 3.13.1

--- a/apps/mealie/values.yaml
+++ b/apps/mealie/values.yaml
@@ -23,9 +23,22 @@ controllers:
           POSTGRES_SERVER: cnpg-pooler-rw.cnpg-cluster.svc
           POSTGRES_PORT: "5432"
           POSTGRES_DB: mealiedb
+          # authentik OIDC (client id/secret come from the oidc-secret envFrom)
+          OIDC_AUTH_ENABLED: "true"
+          OIDC_PROVIDER_NAME: authentik
+          OIDC_CONFIGURATION_URL: https://authentik.${EXTERNAL_DOMAIN}/application/o/mealie/.well-known/openid-configuration
+          OIDC_USER_CLAIM: email
+          OIDC_SIGNUP_ENABLED: "true"
+          OIDC_USER_GROUP: mealie-users
+          OIDC_ADMIN_GROUP: mealie-admins
+          OIDC_REMEMBER_ME: "true"
+          # Keep the password form reachable during migration; flip on afterward.
+          OIDC_AUTO_REDIRECT: "false"
         envFrom:
           - secretRef:
               name: db-secret
+          - secretRef:
+              name: oidc-secret
         probes:
           liveness:
             enabled: true

--- a/infrastructure/kube-prometheus/grafana-oauth-secret.sops.yaml
+++ b/infrastructure/kube-prometheus/grafana-oauth-secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: grafana-oauth
+    namespace: monitoring
+type: Opaque
+stringData:
+    GF_AUTH_GENERIC_OAUTH_CLIENT_ID: ENC[AES256_GCM,data:ueVTqS2in/WJ4DCWiQdKZHjkMp5zOUoksAG1vaDGvzJbwrvNadsjMA==,iv:j7ODNjWpHOqKNPOJX6W4vI7F+l9Htcs3/1U/iJjiGIE=,tag:SpXYK25ady4gq08kho2B7Q==,type:str]
+    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:KgY2TsJfUei3KZeisAPmJ3FfFtxyGL3duGVPKN7St/UVxan9+6661NR8S8pCHE+kdGY6GrqPWcKH3S20JkBx/vl2glxH52AgoiftQ1gnwqNvZXO7l8eld0ZDu8YgnZp45bcBOrvW1juYYCEJTN2VMOTvMT4Vkbrw1yoPcQSIGdo=,iv:qJ0mM1ZDVtpo3KwUIAoLo4e6106Oh585roBRmw9eQPU=,tag:gRMLchC/ppgh/Stajx5vVA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0dUQrZk95MkxJaXdkMDVi
+            MEx2MFpISW53eSs1UUxnTHhoVHhZN1I5RUdJClp0aXZnT2tIUXJrK3c5L0ExanJr
+            Sm5wbXpWVGEwQ0s3Y3JKdW85OE45UE0KLS0tIHBxNzM0RlREaVVmTWJ2VE8yUzBS
+            T0IzbG8yUk1RcUt0MU5BZVJOV203K1kKK5nl+3h9J4ii6Ub/v5cU9wbBBIQBPA/N
+            hHYaem+6DQsYhvYAkWqfvefN2iL+vEKVWtYZFm6m+AdbN5IshhgCQg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1d06qu8eegt8wf8pewe8gw50jrrxt8wwzjhqhxgnl7f4myq9dzdxsdrps49
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-17T15:27:20Z"
+    mac: ENC[AES256_GCM,data:5bJjvSxAxZaM9zib6knesNJA+fcye7t0wrjWLOvoN2NxTmgw5z2RcHixFURSu1KZtLOwvfuOZt5MHpu5ffRL8CfY8cPInMgR8AL2F6GBxUyqZH1uJMbMIXVMbCFx219gyAegZpJOW7FIOOVmeBfWqkJdXaOOxGliM5NQmlZDNiM=,iv:NsClPwqKv5VCOfUuUA5QBBUebor79MuGi5jCeyQc/Fg=,tag:YAsxEYsGgxA92GwmEC6qaQ==,type:str]
+    version: 3.13.1

--- a/infrastructure/kube-prometheus/kustomization.yaml
+++ b/infrastructure/kube-prometheus/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - dashboard-ah-lcg.sops.yaml
   - datasource-scrapydb.yaml
   - scrapy-grafana-secret.sops.yaml
+  - grafana-oauth-secret.sops.yaml
   - prometheusrule-pod-terminations.yaml
 patches:
   # Grafana dashboard JSON contains ${var} template tokens that collide with

--- a/infrastructure/kube-prometheus/values.yaml
+++ b/infrastructure/kube-prometheus/values.yaml
@@ -4,6 +4,34 @@ grafana:
     userKey: admin-user
     passwordKey: admin-password
   envFromSecret: scrapy-grafana
+  # authentik OIDC client id/secret (read by Grafana as [auth.generic_oauth])
+  envValueFrom:
+    GF_AUTH_GENERIC_OAUTH_CLIENT_ID:
+      secretKeyRef:
+        name: grafana-oauth
+        key: GF_AUTH_GENERIC_OAUTH_CLIENT_ID
+    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET:
+      secretKeyRef:
+        name: grafana-oauth
+        key: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
+  grafana.ini:
+    server:
+      root_url: https://grafana.${EXTERNAL_DOMAIN}
+    auth:
+      # Link the existing local Grafana users to authentik by email.
+      oauth_allow_insecure_email_lookup: true
+      # Keep the password form reachable during migration; flip on afterward.
+      oauth_auto_login: false
+      signout_redirect_url: https://authentik.${EXTERNAL_DOMAIN}/application/o/grafana/end-session/
+    auth.generic_oauth:
+      enabled: true
+      name: authentik
+      scopes: openid email profile
+      auth_url: https://authentik.${EXTERNAL_DOMAIN}/application/o/authorize/
+      token_url: https://authentik.${EXTERNAL_DOMAIN}/application/o/token/
+      api_url: https://authentik.${EXTERNAL_DOMAIN}/application/o/userinfo/
+      # Map authentik group membership (groups claim) to Grafana roles.
+      role_attribute_path: contains(groups[*], 'grafana-admins') && 'Admin' || contains(groups[*], 'grafana-editors') && 'Editor' || 'Viewer'
   service:
     type: LoadBalancer
   ingress:


### PR DESCRIPTION
## Context
Second of three PRs wiring the homelab to **authentik** SSO. This one covers the **uncritical** services: Grafana, Mealie, Immich, Jellyfin.

> Stacked on `authentik-base` (PR #276) — merge that first. Base branch is set to `authentik-base` so the diff is scoped to this PR's work.

## Approach
authentik objects are declared as a **Blueprint** (`apps/authentik/blueprints/homelab-uncritical.yaml`) — 5 groups, 4 OAuth2 providers, 4 applications. Client IDs/secrets live in one SOPS secret injected into the authentik server+worker via `envFrom`, and the blueprint references them with `!Env`, so the blueprint file contains no secrets.

**Role mapping uses the authentik `groups` claim** (emitted by the default `profile` scope) rather than application entitlements — simpler and robust, fully authentik-docs-backed. Groups: `grafana-admins`/`grafana-editors`, `mealie-admins`/`mealie-users`.

## Per-app
- **Grafana** (declarative) — `[auth.generic_oauth]` in `grafana.ini`; client id/secret via `envValueFrom` → `grafana-oauth` secret; `role_attribute_path` maps the groups claim to Admin/Editor/Viewer. `oauth_allow_insecure_email_lookup=true` so the **existing local users link by email**. `oauth_auto_login` left **off** for migration (reach the password form at `/login`).
- **Mealie** (declarative) — `OIDC_*` env; `OIDC_USER_CLAIM=email` links existing users; groups → `mealie-admins`/`mealie-users`; client id/secret via `oidc-secret`. `OIDC_AUTO_REDIRECT` left **off** for migration.
- **Immich** — provider/application created here; **enable OAuth in Immich's admin UI** (Administration → Settings → OAuth Authentication). Issuer `https://authentik.${EXTERNAL_DOMAIN}/application/o/immich/`, scope `openid email profile`. Links existing users by **email** (lowercase, exact case). Read the client id/secret with `sops -d apps/authentik/authentik-oidc-credentials.sops.yaml`.
- **Jellyfin** — provider/application created here; **install the SSO-Auth plugin** (`9p4`) and configure it in the Jellyfin dashboard. OID endpoint `https://authentik.${EXTERNAL_DOMAIN}/application/o/jellyfin/.well-known/openid-configuration`. Links by **username**; existing users can self-link at `/SSOViews/linking`.

## Verification
- `kustomize build apps` and `kustomize build infrastructure/kube-prometheus` succeed; yamllint passes; blueprint parses (5 groups / 4 providers / 4 apps).
- After reconcile: authentik System → Blueprints shows `homelab-sso-uncritical` applied; the 4 applications exist. Test login per app and confirm **existing users link** (no duplicates) before flipping auto-login/auto-redirect on. Full migration runbook in the plan.

## Notes
- OIDC discovery is via the external authentik hostname (issuer must match the token issuer); ensure in-cluster DNS resolves `authentik.${EXTERNAL_DOMAIN}` to the Traefik LB.
- Migration of the two existing users happens after merge per the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)