### PR TITLE
Pin authentik hostname to Traefik IP for in-cluster OIDC

### DIFF
--- a/apps/authentik/authentik-client-values.yaml
+++ b/apps/authentik/authentik-client-values.yaml
@@ -1,0 +1,14 @@
+# Shared app-template values for authentik OIDC clients. Mounted into each
+# client's HelmRelease via an extra valuesFrom by the authentik-client Kustomize
+# component (apps/components/authentik-client).
+#
+# Pods resolve the external domain through CoreDNS -> router -> public, which
+# returns Cloudflare's IP; the LAN-only authentik then can't be reached (525).
+# Pin authentik's hostname to the Traefik LoadBalancer IP, mirroring blocky's
+# customDNS mapping (apps/blocky/values.yaml) so server-side OIDC calls stay on
+# the LAN with a valid wildcard cert.
+defaultPodOptions:
+  hostAliases:
+    - ip: 192.168.2.18
+      hostnames:
+        - authentik.${EXTERNAL_DOMAIN}

--- a/apps/authentik/kustomization.yaml
+++ b/apps/authentik/kustomization.yaml
@@ -10,6 +10,12 @@ configMapGenerator:
     namespace: flux-system
     files:
       - values.yaml
+  # Shared values for OIDC client apps, consumed via the authentik-client
+  # Kustomize component (apps/components/authentik-client).
+  - name: authentik-client-values
+    namespace: flux-system
+    files:
+      - values.yaml=authentik-client-values.yaml
   - name: authentik-blueprints
     namespace: authentik
     files:

--- a/apps/components/authentik-client/kustomization.yaml
+++ b/apps/components/authentik-client/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+# Opt an app-template app in as an authentik OIDC client: prepend the shared
+# authentik-client-values ConfigMap (generated once in apps/authentik) to the
+# app's HelmRelease valuesFrom. Inserting at index 0 keeps the shared values
+# FIRST so the app's own values still win on conflicts; Flux deep-merges the
+# shared defaultPodOptions.hostAliases with any defaultPodOptions the app sets.
+patches:
+  - target:
+      kind: HelmRelease
+    patch: |
+      - op: add
+        path: /spec/valuesFrom/0
+        value:
+          kind: ConfigMap
+          name: authentik-client-values
+          valuesKey: values.yaml

--- a/apps/immich/kustomization.yaml
+++ b/apps/immich/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+components:
+  - ../components/authentik-client
 resources:
   - namespace.yaml
   - immich-library-pvc.yaml

--- a/apps/jellyfin/kustomization.yaml
+++ b/apps/jellyfin/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+components:
+  - ../components/authentik-client
 configMapGenerator:
   - name: jellyfin-values
     namespace: flux-system

--- a/apps/mealie/kustomization.yaml
+++ b/apps/mealie/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+components:
+  - ../components/authentik-client
 resources:
   - namespace.yaml
   - app-data.yaml

--- a/infrastructure/kube-prometheus/values.yaml
+++ b/infrastructure/kube-prometheus/values.yaml
@@ -3,6 +3,13 @@ grafana:
     existingSecret: grafana-admin
     userKey: admin-user
     passwordKey: admin-password
+  # Pin authentik's hostname to the Traefik LB IP so Grafana's server-side OIDC
+  # calls stay on the LAN (mirrors blocky). Not app-template, so it can't use
+  # the authentik-client component.
+  hostAliases:
+    - ip: 192.168.2.18
+      hostnames:
+        - authentik.${EXTERNAL_DOMAIN}
   envFromSecret: scrapy-grafana
   # authentik OIDC client id/secret (read by Grafana as [auth.generic_oauth])
   envValueFrom:


### PR DESCRIPTION
## Context
After merging the uncritical-services SSO PR, **Mealie login fails** with:
```
httpx.HTTPStatusError: Server error '525 <none>' for url
```
**525 is a Cloudflare code** (origin SSL handshake failed). Root cause: pods resolve the external domain via **CoreDNS → router (192.168.2.1) → public → Cloudflare IP**, then try to reach the **LAN-only** authentik through Cloudflare, which has no origin to handshake with. Browsers on the LAN work because **blocky** maps `${EXTERNAL_DOMAIN} → 192.168.2.18` (Traefik) — but CoreDNS doesn't use blocky. This breaks **every server-side OIDC call** (Mealie, Grafana, Immich, Jellyfin), not just Mealie.

## Fix
Per-pod **`hostAliases`** mapping `authentik.${EXTERNAL_DOMAIN} → 192.168.2.18`, mirroring blocky's mapping. Traffic stays on the LAN (MetalLB L2 hairpin), Traefik serves the wildcard cert, and the OIDC issuer stays consistent. No cluster-DNS surgery, no blocky cold-start dependency.

DRY'd via a reusable **Kustomize Component** (`apps/components/authentik-client`): since the pods are Helm-rendered (a kustomize patch can't touch them), the component prepends a shared `authentik-client-values` ConfigMap to the app's HelmRelease `valuesFrom`. The hostAlias is defined **once** (`apps/authentik/authentik-client-values.yaml`); Flux deep-merges it with each app's own `defaultPodOptions`, and the app's values stay first-class (listed last, so they win on conflicts).

- **mealie, immich, jellyfin** opt in with one line: `components: [../components/authentik-client]`.
- **Grafana** is the exception (kube-prometheus-stack, not app-template) → `grafana.hostAliases` set directly.

## Verification
- `kustomize build apps` + `kustomize build infrastructure/kube-prometheus` succeed; the Mealie HelmRelease shows both `valuesFrom` (shared first, `mealie-values` second); yamllint/prek pass.
- After reconcile: `kubectl -n mealie get pod <pod> -o yaml | grep -A4 hostAliases` shows the mapping; from a pod `getent hosts authentik.${REMOTE}` → `192.168.2.18`; the discovery URL returns `200` (no 525); Mealie SSO login completes and links the existing user by email.

## Follow-up
When PR3 (Paperless, Home Assistant) lands, add `components: [../components/authentik-client]` to those two as well so they don't ship the same bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)